### PR TITLE
Add quick nav links to student curriculum pages

### DIFF
--- a/app/javascript/courses/curricula/components/CoursesCurriculum.re
+++ b/app/javascript/courses/curricula/components/CoursesCurriculum.re
@@ -264,16 +264,16 @@ let navigationLink = (direction, level, setState) => {
       <FaIcon classes={"fas " ++ icon} />
     );
 
-  <div
+  <button
     onClick={_ =>
       setState(state => {...state, selectedLevelId: level |> Level.id})
     }
-    className="block p-4 text-center border rounded-lg bg-gray-100 hover:bg-gray-200 cursor-pointer">
+    className="block w-full focus:outline-none p-4 text-center border rounded-lg bg-gray-100 hover:bg-gray-200 cursor-pointer">
     {arrow(leftIcon)}
     <span className="mx-2 hidden md:inline"> {longText |> str} </span>
     <span className="mx-2 inline md:hidden"> {shortText |> str} </span>
     {arrow(rightIcon)}
-  </div>;
+  </button>;
 };
 
 let quickNavigationLinks = (levels, selectedLevel, setState) => {

--- a/app/javascript/courses/curricula/components/CoursesCurriculum.re
+++ b/app/javascript/courses/curricula/components/CoursesCurriculum.re
@@ -558,6 +558,7 @@ let make =
             : handleLockedLevel(currentLevel)}
        </div>
      }}
-    {quickNavigationLinks(levels, selectedLevel, setState)}
+    {state.showLevelZero
+       ? React.null : quickNavigationLinks(levels, selectedLevel, setState)}
   </div>;
 };

--- a/app/javascript/courses/curricula/components/CoursesCurriculum.re
+++ b/app/javascript/courses/curricula/components/CoursesCurriculum.re
@@ -450,20 +450,19 @@ let make =
      | LevelUp => React.null
      | _anyOtherNotice =>
        <div>
-         <div className="px-3">
-           <CoursesCurriculum__LevelSelector
-             levels
-             selectedLevelId={state.selectedLevelId}
-             setSelectedLevelId={selectedLevelId =>
-               setState(state => {...state, selectedLevelId})
-             }
-             showLevelZero={state.showLevelZero}
-             setShowLevelZero={showLevelZero =>
-               setState(state => {...state, showLevelZero})
-             }
-             levelZero
-           />
-         </div>
+         <CoursesCurriculum__LevelSelector
+           levels
+           teamLevel
+           selectedLevelId={state.selectedLevelId}
+           setSelectedLevelId={selectedLevelId =>
+             setState(state => {...state, selectedLevelId})
+           }
+           showLevelZero={state.showLevelZero}
+           setShowLevelZero={showLevelZero =>
+             setState(state => {...state, showLevelZero})
+           }
+           levelZero
+         />
          {currentLevel |> Level.isLocked && accessLockedLevels
             ? <div
                 className="text-center p-3 mt-5 border rounded-lg bg-blue-100 max-w-3xl mx-auto">

--- a/app/javascript/courses/curricula/components/CoursesCurriculum__LevelSelector.re
+++ b/app/javascript/courses/curricula/components/CoursesCurriculum__LevelSelector.re
@@ -27,7 +27,7 @@ let numberedLevelSelector = (selectedLevel, setShowLevelZero) => {
   let additionalClasses =
     switch (setShowLevelZero) {
     | Some(_) => "w-1/2 bg-white px-4 py-2 hover:bg-gray-100 hover:text-primary-500 truncate leading-loose text-sm"
-    | None => "w-full focus:shadow-inner bg-primary-100 border-t border-b px-2 h-10 flex items-center justify-between"
+    | None => "w-full rounded-lg bg-primary-100 border-t border-b px-2 h-10 flex items-center justify-between"
     };
 
   <button

--- a/app/javascript/courses/curricula/components/CoursesCurriculum__LevelSelector.re
+++ b/app/javascript/courses/curricula/components/CoursesCurriculum__LevelSelector.re
@@ -76,7 +76,7 @@ let make =
     (
       ~levels,
       ~teamLevel,
-      ~selectedLevelId,
+      ~selectedLevel,
       ~setSelectedLevelId,
       ~showLevelZero,
       ~setShowLevelZero,
@@ -84,13 +84,6 @@ let make =
     ) => {
   let orderedLevels =
     levels |> List.filter(l => l |> Level.number != 0) |> Level.sort;
-
-  let selectedLevel =
-    levels
-    |> ListUtils.unsafeFind(
-         l => l |> Level.id == selectedLevelId,
-         "Could not find selectedLevel with ID " ++ selectedLevelId,
-       );
 
   <div className="px-3 md:px-0">
     <div

--- a/app/javascript/courses/curricula/components/CoursesCurriculum__Overlay.re
+++ b/app/javascript/courses/curricula/components/CoursesCurriculum__Overlay.re
@@ -491,15 +491,10 @@ let performQuickNavigation = (url, send, event) => {
 };
 
 let navigationLink = (direction, url, send) => {
-  let (leftIcon, longText, shortText, rightIcon) =
+  let (leftIcon, text, rightIcon) =
     switch (direction) {
-    | `Previous => (
-        Some("fa-arrow-left"),
-        "Previous Target",
-        "Previous",
-        None,
-      )
-    | `Next => (None, "Next Target", "Next", Some("fa-arrow-right"))
+    | `Previous => (Some("fa-arrow-left"), "Previous Target", None)
+    | `Next => (None, "Next Target", Some("fa-arrow-right"))
     };
 
   let arrow = icon =>
@@ -510,12 +505,19 @@ let navigationLink = (direction, url, send) => {
   <a
     href=url
     onClick={performQuickNavigation(url, send)}
-    className="block p-4 text-center border rounded-lg bg-gray-100 hover:bg-gray-200">
+    className="block p-2 md:p-4 text-center border rounded-lg bg-gray-100 hover:bg-gray-200">
     {arrow(leftIcon)}
-    <span className="mx-2 hidden md:inline"> {longText |> str} </span>
-    <span className="mx-2 inline md:hidden"> {shortText |> str} </span>
+    <span className="mx-2 hidden md:inline"> {text |> str} </span>
     {arrow(rightIcon)}
   </a>;
+};
+
+let scrollOverlayToTop = _event => {
+  let element =
+    Webapi.Dom.(document |> Document.getElementById("target-overlay"));
+  element->Belt.Option.mapWithDefault((), element =>
+    element->Webapi.Dom.Element.setScrollTop(0.0)
+  );
 };
 
 let quickNavigationLinks = (targetDetails, send) => {
@@ -524,28 +526,28 @@ let quickNavigationLinks = (targetDetails, send) => {
   <div className="pb-6">
     <hr className="my-6" />
     <div className="container mx-auto max-w-3xl flex px-3 lg:px-0">
-      {switch (previous, next) {
-       | (Some(previousUrl), Some(nextUrl)) =>
-         [|
-           <div key="previous" className="w-1/2 mr-2">
-             {navigationLink(`Previous, previousUrl, send)}
-           </div>,
-           <div key="next" className="w-1/2 ml-2">
-             {navigationLink(`Next, nextUrl, send)}
-           </div>,
-         |]
-         |> React.array
-
-       | (Some(previousUrl), None) =>
-         <div className="w-full">
-           {navigationLink(`Previous, previousUrl, send)}
-         </div>
-       | (None, Some(nextUrl)) =>
-         <div className="w-full">
-           {navigationLink(`Next, nextUrl, send)}
-         </div>
-       | (None, None) => React.null
-       }}
+      <div className="w-1/3 mr-2">
+        {previous->Belt.Option.mapWithDefault(React.null, previousUrl =>
+           navigationLink(`Previous, previousUrl, send)
+         )}
+      </div>
+      <div className="w-1/3 mx-2">
+        <button
+          onClick=scrollOverlayToTop
+          className="block w-full focus:outline-none p-2 md:p-4 text-center border rounded-lg bg-gray-100 hover:bg-gray-200">
+          <span className="mx-2 hidden md:inline">
+            {"Scroll to Top" |> str}
+          </span>
+          <span className="mx-2 md:hidden">
+            <i className="fas fa-arrow-up" />
+          </span>
+        </button>
+      </div>
+      <div className="w-1/3 ml-2">
+        {next->Belt.Option.mapWithDefault(React.null, nextUrl =>
+           navigationLink(`Next, nextUrl, send)
+         )}
+      </div>
     </div>
   </div>;
 };

--- a/app/javascript/courses/curricula/components/CoursesCurriculum__Overlay.re
+++ b/app/javascript/courses/curricula/components/CoursesCurriculum__Overlay.re
@@ -101,10 +101,11 @@ let scrollCompleteButtonIntoViewEventually = () => {
       | Some(e) =>
         Webapi.Dom.Element.scrollIntoView(e);
         e->Webapi.Dom.Element.setClassName("mt-4 complete-button-selected");
-      | None => ()
+      | None =>
+        Rollbar.error("Could not find the 'Complete' button to scroll to.")
       };
     },
-    100,
+    50,
   )
   |> ignore;
 };

--- a/app/javascript/courses/curricula/types/CoursesCurriculum__Level.re
+++ b/app/javascript/courses/curricula/types/CoursesCurriculum__Level.re
@@ -47,3 +47,20 @@ let unlockDateString = t =>
   | Some(unlockOn) =>
     unlockOn |> DateFns.parseString |> DateFns.format("MMM D")
   };
+
+let findByLevelNumber = (levels, levelNumber) =>
+  levels |> List.find_opt(l => l.number == levelNumber);
+
+let next = (levels, t) => {
+  t.number + 1 |> findByLevelNumber(levels);
+};
+
+let previous = (levels, t) => {
+  let previousLevelNumber = t.number - 1;
+
+  if (previousLevelNumber == 0) {
+    None;
+  } else {
+    previousLevelNumber |> findByLevelNumber(levels);
+  };
+};

--- a/app/javascript/courses/curricula/types/CoursesCurriculum__TargetDetails.re
+++ b/app/javascript/courses/curricula/types/CoursesCurriculum__TargetDetails.re
@@ -1,3 +1,8 @@
+type navigation = {
+  previous: option(string),
+  next: option(string),
+};
+
 type t = {
   pendingUserIds: list(string),
   submissions: list(CoursesCurriculum__Submission.t),
@@ -10,18 +15,26 @@ type t = {
   evaluated: bool,
   grading: list(CoursesCurriculum__Grade.t),
   completionInstructions: option(string),
+  navigation,
 };
 
 let submissions = t => t.submissions;
 let submissionAttachments = t => t.submissionAttachments;
 let pendingUserIds = t => t.pendingUserIds;
 let feedback = t => t.feedback;
+let navigation = t => (t.navigation.previous, t.navigation.next);
 
 type completionType =
   | Evaluated
   | TakeQuiz
   | LinkToComplete
   | MarkAsComplete;
+
+let decodeNavigation = json =>
+  Json.Decode.{
+    previous: json |> optional(field("previous", string)),
+    next: json |> optional(field("next", string)),
+  };
 
 let decode = json =>
   Json.Decode.{
@@ -51,6 +64,7 @@ let decode = json =>
       json
       |> field("completionInstructions", nullable(string))
       |> Js.Null.toOption,
+    navigation: json |> field("navigation", decodeNavigation),
   };
 
 let computeCompletionType = targetDetails => {

--- a/app/javascript/courses/curricula/types/CoursesCurriculum__TargetDetails.re
+++ b/app/javascript/courses/curricula/types/CoursesCurriculum__TargetDetails.re
@@ -95,3 +95,13 @@ let grades = (submissionId, t) =>
   |> List.filter(grade =>
        grade |> CoursesCurriculum__Grade.submissionId == submissionId
      );
+
+let addSubmission = (submission, t) => {
+  ...t,
+  submissions: [submission, ...t |> submissions],
+};
+
+let addSubmissionAttachments = (attachments, t) => {
+  ...t,
+  submissionAttachments: attachments @ (t |> submissionAttachments),
+};

--- a/app/javascript/shared/components/Dropdown.re
+++ b/app/javascript/shared/components/Dropdown.re
@@ -14,8 +14,12 @@ let toggleDropdown = (setShowDropdown, event) => {
   setShowDropdown(showDropdown => !showDropdown);
 };
 
+let containerClasses = className => {
+  "dropdown inline-block relative text-sm " ++ className;
+};
+
 [@react.component]
-let make = (~selected, ~contents, ~right=false) => {
+let make = (~selected, ~contents, ~right=false, ~className="w-full md:w-auto") => {
   let (showDropdown, setShowDropdown) = React.useState(() => false);
 
   React.useEffect1(
@@ -37,7 +41,7 @@ let make = (~selected, ~contents, ~right=false) => {
   );
 
   <div
-    className="dropdown inline-block relative text-sm w-full md:w-auto"
+    className={containerClasses(className)}
     onClick={toggleDropdown(setShowDropdown)}>
     <div> selected </div>
     {showDropdown

--- a/app/services/targets/details_service.rb
+++ b/app/services/targets/details_service.rb
@@ -33,6 +33,7 @@ module Targets
 
     def default_props
       {
+        navigation: links_to_adjacent_targets,
         quiz_questions: quiz_questions,
         content_blocks: content_blocks,
         communities: community_details,
@@ -40,6 +41,29 @@ module Targets
         evaluated: @target.evaluation_criteria.exists?,
         completion_instructions: @target.completion_instructions
       }
+    end
+
+    def links_to_adjacent_targets
+      links = {}
+
+      sorted_target_ids = @target.level
+        .target_groups
+        .joins(:targets)
+        .merge(Target.live)
+        .order('target_groups.sort_index', 'targets.sort_index')
+        .pluck('targets.id')
+
+      target_index = sorted_target_ids.index(@target.id)
+
+      if target_index.present?
+        previous_target_id = sorted_target_ids[target_index - 1] if target_index.positive?
+        next_target_id = sorted_target_ids[target_index + 1]
+
+        links[:previous] = "/targets/#{previous_target_id}" if previous_target_id.present?
+        links[:next] = "/targets/#{next_target_id}" if next_target_id.present?
+      end
+
+      links
     end
 
     def communities

--- a/db/seeds/development/targets.seeds.rb
+++ b/db/seeds/development/targets.seeds.rb
@@ -6,20 +6,20 @@ after 'development:evaluation_criteria', 'development:target_groups' do
   # Random targets and sessions for every level.
   TargetGroup.all.each do |target_group|
     # Create a regular submittable target.
-    submittable_target = target_group.targets.create!(title: Faker::Lorem.sentence, role: Target.valid_roles.sample, resubmittable: true, visibility: 'live')
+    submittable_target = target_group.targets.create!(title: Faker::Lorem.sentence, role: Target.valid_roles.sample, resubmittable: true, visibility: 'live', sort_index: 0)
     submittable_target.target_evaluation_criteria.create!(evaluation_criterion: submittable_target.course.evaluation_criteria.first)
 
     # Add a target with a link to complete.
-    target_group.targets.create!(title: Faker::Lorem.sentence, role: Target::ROLE_TEAM, link_to_complete: 'https://www.example.com', visibility: 'live')
+    target_group.targets.create!(title: Faker::Lorem.sentence, role: Target::ROLE_TEAM, link_to_complete: 'https://www.example.com', visibility: 'live', sort_index: 1)
 
     # Add a target that can be marked as complete.
-    target_group.targets.create!(title: Faker::Lorem.sentence, role: Target::ROLE_TEAM, visibility: 'live')
+    target_group.targets.create!(title: Faker::Lorem.sentence, role: Target::ROLE_TEAM, visibility: 'live', sort_index: 2)
 
     # Add a target with a quiz - we'll create the quiz in quiz.seeds.rb.
-    target_group.targets.create!(title: "Quiz: #{Faker::Lorem.sentence}", role: Target.valid_roles.sample, resubmittable: true, visibility: 'live')
+    target_group.targets.create!(title: "Quiz: #{Faker::Lorem.sentence}", role: Target.valid_roles.sample, resubmittable: true, visibility: 'live', sort_index: 3)
 
     # Create two other targets in archived and draft state.
-    target_group.targets.create!(title: Faker::Lorem.sentence, role: Target.valid_roles.sample, resubmittable: true, visibility: 'archived', safe_to_change_visibility: true)
-    target_group.targets.create!(title: Faker::Lorem.sentence, role: Target.valid_roles.sample, resubmittable: true, visibility: 'draft', safe_to_change_visibility: true)
+    target_group.targets.create!(title: Faker::Lorem.sentence, role: Target.valid_roles.sample, resubmittable: true, visibility: 'archived', safe_to_change_visibility: true, sort_index: 4)
+    target_group.targets.create!(title: Faker::Lorem.sentence, role: Target.valid_roles.sample, resubmittable: true, visibility: 'draft', safe_to_change_visibility: true, sort_index: 5)
   end
 end

--- a/spec/system/courses/curriculum_spec.rb
+++ b/spec/system/courses/curriculum_spec.rb
@@ -181,6 +181,29 @@ feature "Student's view of Course Curriculum", js: true do
     expect(page).not_to have_content(level_6_target.title)
   end
 
+  scenario 'student navigates between levels using the quick navigation links' do
+    sign_in_user student.user, referer: curriculum_course_path(course)
+
+    expect(page).to have_button("L4: #{level_4.name}")
+
+    click_button 'Next Level'
+
+    expect(page).to have_button("L5: #{level_5.name}")
+
+    click_button 'Next Level'
+
+    expect(page).to have_button("L6: #{locked_level_6.name}")
+    expect(page).not_to have_button('Next Level')
+
+    click_button 'Previous Level'
+    click_button "L5: #{level_5.name}"
+    click_button "L2: #{level_2.name}"
+    click_button 'Previous Level'
+
+    expect(page).to have_button("L1: #{level_1.name}")
+    expect(page).not_to have_button('Previous Level')
+  end
+
   context "when the students's course has a level 0 in it" do
     let(:level_0) { create :level, :zero, course: course }
     let(:target_group_l0) { create :target_group, level: level_0 }

--- a/spec/system/courses/curriculum_spec.rb
+++ b/spec/system/courses/curriculum_spec.rb
@@ -135,18 +135,17 @@ feature "Student's view of Course Curriculum", js: true do
     # ...and only one of thoese should be a milestone target group.
     expect(page).to have_selector('.curriculum__target-group', text: 'MILESTONE TARGETS', count: 1)
 
-    # The 'current level' should be selected.
-    expect(page).to have_select("selected_level", selected: "L4: #{level_4.name}")
+    # Open the level selector dropdown.
+    click_button "L4: #{level_4.name}"
 
-    level_names = [level_1, level_2, level_3, level_4, level_5, locked_level_6].map do |l|
-      "L#{l.number}: #{l.name}"
+    # All levels should be included in the dropdown.
+    [level_1, level_2, level_3, level_5, locked_level_6].each do |l|
+      expect(page).to have_text("L#{l.number}: #{l.name}")
     end
 
-    # All levels should be included in the select dropdown.
-    expect(page).to have_select("selected_level", options: level_names)
-
     # Select another level and check if the correct data is displayed.
-    select("L2: #{level_2.name}", from: 'selected_level')
+    click_button "L2: #{level_2.name}"
+
     expect(page).to have_content(target_group_l2.name)
     expect(page).to have_content(target_group_l2.description)
     expect(page).to have_content(completed_target_l2.title)
@@ -160,7 +159,9 @@ feature "Student's view of Course Curriculum", js: true do
     # expect(page).not_to have_selector('.founder-dashboard-togglebar__toggle-btn')
 
     # Visit the read-only level 5 and ensure that content is in read-only mode.
-    select("L5: #{level_5.name}", from: 'selected_level')
+    click_button "L2: #{level_2.name}"
+    click_button "L5: #{level_5.name}"
+
     expect(page).to have_content(target_group_l5.name)
     expect(page).to have_content(target_group_l5.description)
     expect(page).to have_content(level_5_target_1.title)
@@ -169,8 +170,11 @@ feature "Student's view of Course Curriculum", js: true do
 
     expect(page).to have_content('You must level up to complete this target.')
 
+    click_button 'Close'
+
     # Ensure level 6 is displayed as locked. - the content should not be visible.
-    select("L6: #{locked_level_6.name}", from: 'selected_level')
+    click_button "L5: #{level_5.name}"
+    click_button "L6: #{locked_level_6.name}"
 
     expect(page).not_to have_content(target_group_l6.name)
     expect(page).not_to have_content(target_group_l6.description)
@@ -185,7 +189,6 @@ feature "Student's view of Course Curriculum", js: true do
     scenario 'student visits the dashboard' do
       sign_in_user student.user, referer: curriculum_course_path(course)
 
-      expect(page).to have_select('selected_level', selected: "L4: #{level_4.name}")
       expect(page).to have_button(level_0.name)
 
       # Go to the level 0 Tab
@@ -270,20 +273,16 @@ feature "Student's view of Course Curriculum", js: true do
       # Course name should be displayed.
       expect(page).to have_content(course.name)
 
-      # The first level should be selected.
-      expect(page).to have_select("selected_level", selected: "L1: #{level_1.name}")
+      # The first level should be selected, and all levels should be available.
+      click_button "L1: #{level_1.name}"
 
-      level_names = [level_1, level_2, level_3, level_4, level_5, locked_level_6].map do |l|
-        "L#{l.number}: #{l.name}"
+      [level_2, level_3, level_4, level_5, locked_level_6].each do |l|
+        expect(page).to have_button("L#{l.number}: #{l.name}")
       end
 
-      # All levels should be included in the select dropdown.
-      expect(page).to have_select("selected_level", options: level_names)
+      click_button "L6: #{locked_level_6.name}"
 
-      select("L6: #{locked_level_6.name}", from: 'selected_level')
-
-      # Being an admin, level 6 should be open, but there should be a notice saying when the level will open for
-      # 'regular' students.
+      # Being an admin, level 6 should be open, but there should be a notice saying when the level will open for 'regular' students.
       expect(page).to have_content("This level is still locked for students, and will be unlocked on #{locked_level_6.unlock_on.strftime('%b %-d')}")
       expect(page).to have_content(target_group_l6.name)
       expect(page).to have_content(target_group_l6.description)
@@ -293,7 +292,9 @@ feature "Student's view of Course Curriculum", js: true do
       expect(page).not_to have_content(level_6_draft_target.title)
 
       # Visit the level 5 and ensure that content is in 'preview mode'.
-      select("L5: #{level_5.name}", from: 'selected_level')
+      click_button "L6: #{locked_level_6.name}"
+      click_button "L5: #{level_5.name}"
+
       expect(page).to have_content(target_group_l5.name)
       expect(page).to have_content(target_group_l5.description)
       expect(page).to have_content(level_5_target_1.title)
@@ -324,10 +325,10 @@ feature "Student's view of Course Curriculum", js: true do
     scenario 'coach accesses content in locked levels' do
       sign_in_user student.user, referer: curriculum_course_path(course)
 
-      select("L6: #{locked_level_6.name}", from: 'selected_level')
+      click_button "L4: #{level_4.name}"
+      click_button "L6: #{locked_level_6.name}"
 
-      # Being a coach, level 6 should be accessible, but there should be a notice saying when the level will open for
-      # 'regular' students.
+      # Being a coach, level 6 should be accessible, but there should be a notice saying when the level will open for 'regular' students.
       expect(page).to have_content("This level is still locked for students, and will be unlocked on #{locked_level_6.unlock_on.strftime('%b %-d')}")
       expect(page).to have_content(target_group_l6.name)
       expect(page).to have_content(target_group_l6.description)

--- a/spec/system/targets/show_spec.rb
+++ b/spec/system/targets/show_spec.rb
@@ -18,14 +18,14 @@ feature 'Target Overlay', js: true do
   let!(:target_group_l1) { create :target_group, level: level_1, milestone: true }
   let!(:target_group_l2) { create :target_group, level: level_2 }
   let!(:target_l0) { create :target, target_group: target_group_l0 }
-  let!(:target_l1) { create :target, :with_content, target_group: target_group_l1, role: Target::ROLE_TEAM, evaluation_criteria: [criterion_1, criterion_2], completion_instructions: Faker::Lorem.sentence }
+  let!(:target_l1) { create :target, :with_content, target_group: target_group_l1, role: Target::ROLE_TEAM, evaluation_criteria: [criterion_1, criterion_2], completion_instructions: Faker::Lorem.sentence, sort_index: 0 }
   let!(:target_l2) { create :target, target_group: target_group_l2 }
-  let!(:prerequisite_target) { create :target, :with_content, target_group: target_group_l1, role: Target::ROLE_TEAM }
+  let!(:prerequisite_target) { create :target, :with_content, target_group: target_group_l1, role: Target::ROLE_TEAM, sort_index: 2 }
   let!(:target_draft) { create :target, :draft, :with_content, target_group: target_group_l1, role: Target::ROLE_TEAM }
   let!(:target_archived) { create :target, :archived, :with_content, target_group: target_group_l1, role: Target::ROLE_TEAM }
 
   # Quiz target
-  let!(:quiz_target) { create :target, target_group: target_group_l1, days_to_complete: 60, role: Target::ROLE_TEAM, resubmittable: false, completion_instructions: Faker::Lorem.sentence }
+  let!(:quiz_target) { create :target, target_group: target_group_l1, days_to_complete: 60, role: Target::ROLE_TEAM, resubmittable: false, completion_instructions: Faker::Lorem.sentence, sort_index: 3 }
   let!(:quiz) { create :quiz, target: quiz_target }
   let!(:quiz_question_1) { create :quiz_question, quiz: quiz }
   let!(:q1_answer_1) { create :answer_option, quiz_question: quiz_question_1 }
@@ -672,6 +672,30 @@ feature 'Target Overlay', js: true do
         expect(page).to have_button('Submit Quiz', disabled: true)
       end
     end
+  end
+
+  scenario 'student navigates between targets using quick navigation bar' do
+    sign_in_user student.user, referer: target_path(target_l1)
+
+    expect(page).to have_text(target_l1.title)
+
+    expect(page).not_to have_link('Previous Target')
+    click_link 'Next Target'
+
+    expect(page).to have_text(prerequisite_target.title)
+
+    click_link 'Next Target'
+
+    expect(page).to have_text(quiz_target.title)
+    expect(page).not_to have_link('Next Target')
+
+    click_link 'Previous Target'
+
+    expect(page).to have_text(prerequisite_target.title)
+
+    click_link 'Previous Target'
+
+    expect(page).to have_text(target_l1.title)
   end
 
   scenario "student visits a draft target page directly" do


### PR DESCRIPTION
This tackles issues #39 and #119.

## Checklist

- [x] Add navigation buttons to target overlay.
- [x] Fix state management issues in target overlay when switching directly to another target.
- [x] Add a _scroll to top_ button to the target overlay quick nav section.
- [x] Rebuild level selector to use the `Dropdown` component.
- [x] Add icons to indicate level status in its dropdown.
- [x] Add level navigation buttons to curriculum index page.
- [x] Add specs.