### PR TITLE
Fix validation for input fields

### DIFF
--- a/app/javascript/courses/review/components/CoursesReview__ChecklistEditor.re
+++ b/app/javascript/courses/review/components/CoursesReview__ChecklistEditor.re
@@ -156,6 +156,10 @@ let invalidChecklist = reviewChecklist => {
   |> ArrayUtils.isNotEmpty;
 };
 
+let validTitle = title => {
+  title |> String.trim !== "";
+};
+
 [@react.component]
 let make =
     (~reviewChecklist, ~updateReviewChecklistCB, ~closeEditModeCB, ~targetId) => {
@@ -193,9 +197,13 @@ let make =
                     }
                   />
                   <School__InputGroupError
-                    message="Title should be greater than 2 characters"
+                    message="Not a valid title"
                     active={
-                      reviewChecklistItem |> ReviewChecklistItem.title == ""
+                      !(
+                        reviewChecklistItem
+                        |> ReviewChecklistItem.title
+                        |> validTitle
+                      )
                     }
                   />
                 </div>
@@ -295,9 +303,13 @@ let make =
                               }
                             />
                             <School__InputGroupError
-                              message="Title should be greater than 2 characters"
+                              message="Not a valid title"
                               active={
-                                resultItem |> ReviewChecklistResult.title == ""
+                                !(
+                                  resultItem
+                                  |> ReviewChecklistResult.title
+                                  |> validTitle
+                                )
                               }
                             />
                           </div>

--- a/app/javascript/schools/communities/components/SchoolCommunities__Editor.re
+++ b/app/javascript/schools/communities/components/SchoolCommunities__Editor.re
@@ -224,7 +224,7 @@ let make =
     setDirty(_ => true);
   };
 
-  let saveDisabled = name == "" || !dirty;
+  let saveDisabled = name |> String.trim == "" || !dirty;
 
   <div className="mx-8 pt-8">
     <h5 className="uppercase text-center border-b border-gray-400 pb-2">
@@ -250,7 +250,7 @@ let make =
           />
           <School__InputGroupError
             message="is not a valid name"
-            active={dirty ? name == "" : false}
+            active={dirty ? name |> String.trim == "" : false}
           />
         </div>
         <div className="flex items-center mt-6">


### PR DESCRIPTION
- Validation for 'empty-like' strings for community name
- Show validation message at appropriate times for Review Checklist title

![captured (15)](https://user-images.githubusercontent.com/25174717/74594993-72b98780-5062-11ea-9369-c38bae4805f4.gif)


If you'd like the Review Checklist title to be trimmed before validation as well, let me know!
(Wouldn't we want to trim the values before we save them as well?)

Fixes: #206 
