### PR TITLE
Allow coaches to leave a note about a student or a team when reviewing their submissions

### DIFF
--- a/app/graphql/mutations/create_grading.rb
+++ b/app/graphql/mutations/create_grading.rb
@@ -3,6 +3,7 @@ module Mutations
     argument :submission_id, ID, required: true
     argument :grades, [Types::GradeInputType], required: true
     argument :feedback, String, required: false
+    argument :note, String, required: false
 
     description "Create grading for submission"
 

--- a/app/javascript/courses/review/components/CoursesReview__FeedbackEditor.re
+++ b/app/javascript/courses/review/components/CoursesReview__FeedbackEditor.re
@@ -58,6 +58,7 @@ let make =
           value=feedback
           profile=Markdown.Permissive
           maxLength=10000
+          placeholder="This feedback will be emailed to students when you finish grading."
         />
       </div>
     </div>

--- a/app/javascript/courses/review/components/CoursesReview__SubmissionOverlay.re
+++ b/app/javascript/courses/review/components/CoursesReview__SubmissionOverlay.re
@@ -216,6 +216,11 @@ let make =
                  <CoursesReview__Submissions
                    key={index |> string_of_int}
                    submission
+                   teamSubmission={
+                     submissionDetails
+                     |> SubmissionDetails.students
+                     |> Array.length > 1
+                   }
                    targetEvaluationCriteriaIds={
                      submissionDetails
                      |> SubmissionDetails.targetEvaluationCriteriaIds

--- a/app/javascript/courses/review/components/CoursesReview__Submissions.re
+++ b/app/javascript/courses/review/components/CoursesReview__Submissions.re
@@ -180,6 +180,7 @@ let updateSubmission =
 let make =
     (
       ~submission,
+      ~teamSubmission,
       ~updateSubmissionCB,
       ~submissionNumber,
       ~currentCoach,
@@ -219,6 +220,7 @@ let make =
       </div>
       <CoursesReview__GradeCard
         submission
+        teamSubmission
         evaluationCriteria
         targetEvaluationCriteriaIds
         reviewChecklist

--- a/app/queries/create_grading_mutator.rb
+++ b/app/queries/create_grading_mutator.rb
@@ -28,7 +28,7 @@ class CreateGradingMutator < ApplicationQuery
       )
 
       if note.present?
-        submission.startup.founders.each do |student|
+        submission.founders.each do |student|
           CoachNote.create!(note: note, author_id: current_user.id, student_id: student.id)
         end
       end

--- a/app/queries/create_grading_mutator.rb
+++ b/app/queries/create_grading_mutator.rb
@@ -3,6 +3,7 @@ class CreateGradingMutator < ApplicationQuery
 
   property :submission_id, validates: { presence: { message: 'Submission ID is required for grading' } }
   property :feedback, validates: { length: { maximum: 10_000 } }
+  property :note, validates: { length: { maximum: 10_000 } }
   property :grades
 
   validate :require_valid_submission
@@ -25,6 +26,13 @@ class CreateGradingMutator < ApplicationQuery
         evaluator: coach,
         evaluated_at: Time.now
       )
+
+      if note.present?
+        submission.startup.founders.each do |student|
+          CoachNote.create!(note: note, author_id: current_user.id, student_id: student.id)
+        end
+      end
+
       send_feedback if feedback.present?
     end
   end
@@ -38,6 +46,7 @@ class CreateGradingMutator < ApplicationQuery
       faculty: coach,
       timeline_event: submission
     )
+
     StartupFeedbackModule::EmailService.new(startup_feedback).send
   end
 

--- a/docs/reviewing_submissions.md
+++ b/docs/reviewing_submissions.md
@@ -23,7 +23,7 @@ Because students can make multiple submissions to improve their grade on a targe
 
 Reviewing a submission involves going over the work that the student has submitted and deciding assigning it grades on each of its evaluation criteria.
 
-![Reviewing a submission](https://res.cloudinary.com/sv-co/image/upload/v1574335063/pupilfirst_documentation/reviewing_submissions/submission_feedback_and_grading_o4rhqz.png)
+![Reviewing a submission](https://res.cloudinary.com/sv-co/image/upload/v1582529474/pupilfirst_documentation/reviewing_submissions/submission_checklist_feedback_notes_and_grading_mgobsx.png)
 
 There's quite a bit to unpack here, so we'll go over each element one by one, starting with the _Grade Card_.
 
@@ -58,4 +58,11 @@ Over the course of reviewing many student submissions, it's very likely that you
 
 You can also revise the template over time, as your understanding of student's issues improves. This can also be really helpful if you're working with other coaches, all of whom can edit the checklist, letting your _collective_ knowledge improve the quality of the feedback.
 
+## Leaving Notes
+
+You can write down notes about a student while you're reviewing a submission. These [notes will be stored in a student's report](/student_reports?id=keep-notes-on-students), and can be viewed only by you and other coaches.
+
+If the submission you're leaving a note on is from a _team_, then the note will be posted to the report of all students in that team.
+
+?> **We'd appreciate any feedback you have about this process!**\
 The greater the difficultly of a course, the greater the importance of a good review process and targeted feedback. As always, if your experience as a teacher has shown you new approaches or techniques, our team at PupilFirst would be more than happy to [have a conversation about it](mailto:support@pupilfirst.com).

--- a/docs/student_reports.md
+++ b/docs/student_reports.md
@@ -16,9 +16,7 @@ However, some levels may be more difficult or time-consuming than others, so you
 
 To get a detailed look at a student's progress, you can click on an entry to open up a report for that student.
 
-![A student's report](https://res.cloudinary.com/sv-co/image/upload/v1574587538/pupilfirst_documentation/student_reports/student_report_kcl1ms.png)
-
-!> The above image is the _proposed_ design for the report page that is being built right now, and is subject to change. To see the latest updates, check out [the related issue on Github](https://github.com/SVdotCO/pupilfirst/issues/78).
+![A student's report](https://res.cloudinary.com/sv-co/image/upload/v1582530863/pupilfirst_documentation/student_reports/student_report_sv4bhj.png)
 
 ## Grading should be objective
 

--- a/graphql_schema.json
+++ b/graphql_schema.json
@@ -4794,6 +4794,16 @@
                   "ofType": null
                 },
                 "defaultValue": null
+              },
+              {
+                "name": "note",
+                "description": "",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                },
+                "defaultValue": null
               }
             ],
             "type": {


### PR DESCRIPTION
## Checklist

- [x] Add a help icon to explain the feature.
- [x] Customize the heading depending on whether submission is from a single student or from a team.
- [x] Send the note along when the grading is saved.
- [x] Make sure a _blank_ note is ignored by the server.